### PR TITLE
Fix Optional Typescript GitHub CI Check to Only Run on /^ts-*/ Branch Based PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,14 +9,14 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: '41 6 * * 4'
 
@@ -32,40 +32,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -44,9 +44,32 @@ jobs:
       - name: Lint with Prettier
         run: yarn run lint
 
+        ########################################################################
+        # Optional Typescript Strict Type Checking
+        #
+        # Wow... There is a finely nuanced difference between a pull_request
+        # event and a push event, I believe the pull request event happens only
+        # at the time of pull request creation.  Pushing to a branch that is
+        # part of a pull request is just a push event. Here's a easy to see
+        # what data you have access to in the github context:
+        #
+        #    - name: GitHub Context
+        #      env:
+        #        GITHUB_CONTEXT: ${{ toJSON(github) }}
+        #      run: echo "$GITHUB_CONTEXT"
+
+      - name: Extract Head Ref Branch
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
       - name: Check Typescript
-        if: ${{ startsWith('ts-', github.head_ref) || contains('typescript', github.head_ref) }}
+        if: ${{ startsWith('ts-', $HEAD_BRANCH) || contains('typescript', $HEAD_BRANCH) }}
         run: yarn run types:strict
+        env:
+          HEAD_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+
+        ########################################################################
 
       - name: Build with NextJS
         run: yarn run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -66,7 +66,7 @@ jobs:
         # For a long time the following looked very reasonable to me because I
         # didn't understand that the `if` runs before the step is assigned to a
         # runner, so the local $HEAD_BRANCH variable is not available when the
-        # `if` runs the check. 
+        # `if` runs the check.
         #
         #    - name: Check Typescript
         #      if: ${{ startsWith('ts-', $HEAD_BRANCH) || contains('typescript', $HEAD_BRANCH) }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -63,12 +63,29 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
-      - name: Check Typescript
-        if: ${{ startsWith('ts-', $HEAD_BRANCH) || contains('typescript', $HEAD_BRANCH) }}
-        run: yarn run types:strict
-        env:
-          HEAD_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+        # For a long time the following looked very reasonable to me because I
+        # didn't understand that the `if` runs before the step is assigned to a
+        # runner, so the local $HEAD_BRANCH variable is not available when the
+        # `if` runs the check. 
+        #
+        #    - name: Check Typescript
+        #      if: ${{ startsWith('ts-', $HEAD_BRANCH) || contains('typescript', $HEAD_BRANCH) }}
+        #      run: yarn run types:strict
+        #      env:
+        #        HEAD_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+        #
+        # Instead we have to use the `steps` context
+        # which is available to us in both the job scheduler that assigns steps
+        # to machines and the runners who run the tests.
 
+      - name: Check Typescript
+        if: ${{ startsWith('ts-', steps.extract_branch.outputs.branch) || contains('typescript', steps.extract_branch.outputs.branch) }}
+        run: yarn run types:strict
+
+        # * https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+        # * https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
+        # * https://docs.github.com/en/actions/reference/environment-variables
+        # * https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
         ########################################################################
 
       - name: Build with NextJS

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -78,7 +78,7 @@ jobs:
         # which is available to us in both the job scheduler that assigns steps
         # to machines and the runners who run the tests.
 
-      - name: Check Typescript
+      - name: Strict Typescript Check
         if: ${{ startsWith('ts-', steps.extract_branch.outputs.branch) || contains('typescript', steps.extract_branch.outputs.branch) }}
         run: yarn run types:strict
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -18,12 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
I've broken these commits out of the previous CI plus README notes, and I'm pretty confident that these aren't going to present any conflicts for PRs that are currently in flight.

Here's the main part of the README that will be coming up in a separate PR soon:



#### Typescript (completely optional)

Typescript is enabled throughout the project, and to opt in, create a working branch where the name of the branch begins with `ts-` or contains the word `typescript` (and capitalization matters for both of those).

> Be forewarned that this process will require writing types for everyone who
> has elected to not write any types before a branch will pass `tarn types:strict`. So don't surprised, and don't go down this road unless you are specifically looking to practice a lot and overtrain to excel during interviews.

When you begin a branch name with `ts-`, the CI system will run `yarn types:strict` in addition to the other tests. Once the tests all pass, the merge button will be available.

For convenience during development, run `yarn watch:types:strict` and the the type checker will update the test results every time you save a file.

- Here's [the NextJS intro to the types they provide](https://nextjs.org/learn/excel/typescript/nextjs-types)
- And here's [an example PR that shows this process in action](https://github.com/code-circles/main-app/pull/9).
