### PR TITLE
Add local postgres via Docker

### DIFF
--- a/.env
+++ b/.env
@@ -4,4 +4,5 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL and SQLite.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgres://bajeonmlxpbfdq:bbe0a9d989587bb4c4b66aac1c3e4c0af75f8347c0b6128e1bb7d2a8fbc213d7@ec2-3-214-136-47.compute-1.amazonaws.com:5432/d1p1l0ndqdjtj4"
+# this URL will point to a local running Docker container running postgres, see README for details
+DATABASE_URL=postgres://local:uPw4Rdsn0nw4rDz@localhost:5442/upward

--- a/README.md
+++ b/README.md
@@ -24,17 +24,28 @@ first step in troubleshooting to fix things.
 
 ### Next, run the database migrations
 
-Create a .env file and add:
+Please refer to the [local development](docs/local-dev.md) document for details about how to get Docker running on your machine if you don't have it.
 
-DATABASE_URL="postgres://bajeonmlxpbfdq:bbe0a9d989587bb4c4b66aac1c3e4c0af75f8347c0b6128e1bb7d2a8fbc213d7@ec2-3-214-136-47.compute-1.amazonaws.com:5432/d1p1l0ndqdjtj4"
+To create a local Docker container running your postgres instance, type:
+
+```sh
+npm run create-db
+```
 
 We use [prisma](https://www.prisma.io/nextjs#nextjs-tabs) as an ORM to postgres to connect directly to the database. See example in index.tsx
 
 Download the [prisma studio](https://github.com/prisma/studio/releases) to connect directly to the heroku database:
 
-For development: we use prisma to connect to a heroku database on staging
+For development: prisma will connect to your local Docker container
 
-npx prisma generate 
+To update your database schema without generating a new migration (for prototyping data changes):
+
+
+To generate and run all migrations:
+
+```sh
+npm run migrate-db
+```
 
 
 ### Finally, run the development server

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,40 @@
+# Working On Upward (Locally)
+
+## Setting up the Database
+
+### If you'd like Docker but don't have it yet
+
+I recommend using Docker Desktop as it provides a graphical interface for managing docker, keeping it up-to-date, and configuring it.
+
+[Installing on a Mac](https://docs.docker.com/docker-for-mac/install/)
+[Installing on a Windows](https://docs.docker.com/docker-for-windows/install/)
+
+### Once you have Docker
+
+You can create the database for local development using the npm script:
+
+```sh
+npm run create-db
+```
+
+### If working on schema changes
+
+To test schema changes without generating a migration:
+
+```sh
+npm run update-db
+```
+
+### If you _don't_ **want** Docker
+
+You could install Postgres directly on your machine and manage the database that way.
+
+#### Mac
+
+Using homebrew you can simply type: `brew install postgresql` 
+See https://formulae.brew.sh/formula/postgresql#default for more details.
+
+#### Windows
+
+Certified installer: https://www.enterprisedb.com/downloads/postgres-postgresql-downloads
+

--- a/ops/create-db.sh
+++ b/ops/create-db.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# make a directory in the home directory to hold the database files
+# this ensures us that even if the container is destroyed, your local data
+# will not be lost by accident
+mkdir -p ~/upwarddb
+
+# start a docker container from the built image and name it upwarddb
+# this uses environment variables that the container will check during start up
+# in order to initialize the database
+
+# create a new container named upwarddb
+docker run --name upwardpg \
+    -e POSTGRES_DB=upward \
+    -e POSTGRES_USER=local \
+    -e POSTGRES_PASSWORD=uPw4Rdsn0nw4rDz \
+    -p 5442:5432 \
+    -v ~/upwarddb:/var/lib/postgresql/data \
+    -d postgres:12-alpine
+
+# wait for the container
+sleep 5
+
+# generate and apply migrations via prisma
+npx prisma migrate dev --name initialize

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "format": "prettier --write .",
     "ci-at-home": "run-s lint build",
     "types:strict": "npx tsc --strict",
-    "watch:types:strict": "yarn types:strict --watch"
+    "watch:types:strict": "yarn types:strict --watch",
+    "create-db": "./ops/create-db.sh",
+    "migrate-db": "npx prisma generate dev",
+    "update-db": "npx prisma db push"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.35",


### PR DESCRIPTION
### Changes

 * introduces a local dev markdown file to explain how to get Docker (or postgres) installed on your development machine
 * adds a script for creating the Postgres container through Docker
 * adds several npm scripts to make creation, schema update, and migration simple
 * updates environment file to point to the local docker container
 * will no longer have multiple dev instances sharing the staging database

### Risks

 * change to `.env` could cause issues for Heroku, I haven't looked into/tested this yet