### PR TITLE
Change use of `Language` to `Technology` in schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ model User {
   id                    Int      @id @default(autoincrement())
   firstName             String?
   lastName              String?
+  email                 String   @unique
   createdAt             DateTime @default(now())  @map("created_at")
   updatedAt             DateTime @updatedAt       @map("updated_at")
   authenticationMethod  AuthenticationMethod      @default(SELF)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,9 +26,10 @@ model Profile {
   userId            Int
   roleType          RoleType[]
   yearsOfExperience Int
-  frontEndLanguages FrontEndLanguage[]
-  backEndLanguages  BackendLanguage[]
-  databases         Database[]
+  frontEndTechnologies FrontendTechnology[]
+  backEndTechnologies  BackendTechnology[]
+  databases         StorageTechnology[]
+  operations        OperationsTechnology[]
   locationsWanted   LocationWanted[]
   minimumSalary     Int
   maximumSalary     Int
@@ -84,21 +85,27 @@ model RoleType {
   profile Profile[]         @relation(references: [id])
 }
 
-model FrontEndLanguage  {
+model FrontendTechnology  {
   id          Int               @id @default(autoincrement())
-  language    FrontendLanguages  
+  technology  FrontendTechnologies  
   profile     Profile[]         @relation(references: [id])
 }
 
-model BackendLanguage  {
+model BackendTechnology  {
   id          Int                @id @default(autoincrement())
-  language    BackendLanguages  
+  technology  BackendTechnologies  
   profile     Profile[]          @relation(references: [id])
 }
 
-model Database {
+model OperationsTechnology {
   id          Int                 @id @default(autoincrement())
-  language    DatabaseLanguages  
+  technology  OperationsTechnologies  
+  profile     Profile[]           @relation(references: [id])
+}
+
+model StorageTechnology {
+  id          Int                 @id @default(autoincrement())
+  technology  StorageTechnologies  
   profile     Profile[]           @relation(references: [id])
 }
 
@@ -140,36 +147,57 @@ enum Locations {
   PHILADELPHIA
 }
 
-enum BackendLanguages {
+enum BackendTechnologies {
+  CSHARP
+  DJANGO
+  DOTNET
+  ELIXIR
+  JAVA
+  KAFKA
   NODE
   NEST
-  PHP
-  RUBY
-  RAILS
-  PYTHON
-  DJANGO
-  CSHARP
-  DOTNET
-  KUBERNETES
-  DOCKER
-  AWS
-}
-
-enum DatabaseLanguages {
-  SQL
-  NOSQL
-  MANGODB
-  POSTGRES
-  ORACLE
-}
-
-enum FrontendLanguages {
-  REACT
-  JAVASCRIPT
-  VUE
-  ANGULAR
   NEXT
+  PHP
+  PYTHON
+  RABBITMQ
+  RAILS
+  RUBY
+}
+
+enum OperationsTechnologies {
+  ANSIBLE
+  AWS
+  AZURE
+  DIGITALOCEAN
+  DOCKER
+  GCS
+  KUBERNETES  
+  TERRAFORM
+}
+
+enum StorageTechnologies {
+  CASSANDRA
+  COUCHDB
+  DYNAMODB
+  MEMCACHED
+  MONGODB
+  MSSQL
+  MYSQL
+  NOSQL
+  ORACLE
+  POSTGRES
+  REDIS  
+}
+
+enum FrontendTechnologies {
+  ANGULAR
   EMBER
+  FLOW
+  JAVASCRIPT
+  NEXT
+  REACT
+  TYPESCRIPT  
+  VUE  
 }
 
 enum RoleDescription {


### PR DESCRIPTION
### Change

Original schema started with the concepts of frontend, backend, and database languages. To help reduce confusion, this PR changes the use of `Language` to `Technology` and introduces an `Operations` category so that things like cloud providers, automation tooling, hosting tech, etc. can be represented outside of the `backend` category.

### Risk

I haven't actually used Prisma before and I have not tested any changes that might be related to the schema yet. Just getting this into a branch and PR for review/discussion.